### PR TITLE
Relax FSharp.Core version

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,13 +2,13 @@ group AsyncRx
     source https://www.nuget.org/api/v2
     framework: netstandard2.0
 
-    nuget FSharp.Core ~> 4.7
+    nuget FSharp.Core
 
 group AsyncSeq
     source https://www.nuget.org/api/v2
     framework: netstandard2.1
 
-    nuget FSharp.Core ~> 4.7
+    nuget FSharp.Core
     nuget FSharp.Control.AsyncSeq
     nuget FSharp.Control.AsyncRx
 

--- a/paket.lock
+++ b/paket.lock
@@ -4,7 +4,7 @@ GROUP AsyncRx
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://www.nuget.org/api/v2
-    FSharp.Core (4.7.2)
+    FSharp.Core (6.0.6)
 
 GROUP AsyncSeq
 RESTRICTION: == netstandard2.1
@@ -15,7 +15,7 @@ NUGET
     FSharp.Control.AsyncSeq (3.2.1)
       FSharp.Core (>= 4.7.2)
       Microsoft.Bcl.AsyncInterfaces (>= 5.0)
-    FSharp.Core (4.7.2)
+    FSharp.Core (6.0.6)
     Microsoft.Bcl.AsyncInterfaces (6.0)
 
 GROUP Test


### PR DESCRIPTION
Hey!

I was trying to use AsyncRx with some other libraries in an `.fsx` script (namely `Microsoft.AspNetCore.Http.Abstractions 6.0.0.0`) and I was hitting the following error:

```
warning NU1608: Detected package version outside of dependency constraint: FSharp.Control.AsyncRx 1.6.4 requires FSharp.Core (>= 4.7.2 && < 5.0.0) but version FSharp.Core 6.0.1 was resolved.
```

It looks like the version of `FSharp.Core` was pinned with `~> 4.7` - Any idea why?


## Steps taken

  - Unpinned `FSharp.Core` in `paket.dependencies`
  - Ran `dotnet paket update -g AsyncRx FSharp.Core`
  - Ran `dotnet paket update -g AsyncSeq FSharp.Core`
  - Ran `dotnet run --project test` and all tests passed
  - :warning: I did still get some warnings in the console:

    ```
    /usr/lib/dotnet/dotnet6-6.0.108/sdk/6.0.108/Microsoft.Common.CurrentVersion.targets(2304,5): warning MSB3277: References which depend on "FSharp.Core, Version=4.7.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"
[/home/sadbooth/.nuget/packages/fsharp.core/4.7.2/lib/netstandard2.0/FSharp.Core.dll]. [/home/sadbooth/projects/fsharp/AsyncRx/extra/AsyncSeq/FSharp.Control.AsyncRx.AsyncSeq.fsproj]
    /usr/lib/dotnet/dotnet6-6.0.108/sdk/6.0.108/Microsoft.Common.CurrentVersion.targets(2304,5): warning MSB3277:         /home/sadbooth/.nuget/packages/fsharp.core/4.7.2/lib/netstandard2.0/FSharp.Core.dll [/home/sadbooth/projects/fsharp/AsyncRx/extra/AsyncSeq/FSharp.Control.AsyncRx.AsyncSeq.fsproj]
    ```

Now I'm not sure completely unpinning `FSharp.Core` is the right answer, but I am also not great at resolving package dependencies. Should we perhaps pin it at `~> 6.0`, or do you know of any reason for the current constraint?

As you can see, I also updated the `AsyncSeq` group's `FSharp.Core` as I was aiming to keep them in sync.